### PR TITLE
Add hooks to the repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1696,6 +1696,8 @@
     },
     "@testing-library/jest-dom": {
       "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz",
+      "integrity": "sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==",
       "requires": {
         "@babel/runtime": "^7.5.1",
         "chalk": "^2.4.1",
@@ -1710,6 +1712,8 @@
     },
     "@testing-library/react": {
       "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.4.1.tgz",
+      "integrity": "sha512-sta3ui24HPgW92quHyQj6gpOkNgLNx8BX/QOU4k1bddo43ZdqlGwmzCYwL93bExfhergwiau+IzBGl7TCsSFeA==",
       "requires": {
         "@babel/runtime": "^7.8.3",
         "@testing-library/dom": "^6.11.0",
@@ -1717,7 +1721,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "7.2.1"
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-7.2.1.tgz",
+      "integrity": "sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA=="
     },
     "@types/babel__core": {
       "version": "7.1.5",
@@ -11004,6 +11010,8 @@
     },
     "react": {
       "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -11170,6 +11178,8 @@
     },
     "react-dom": {
       "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
+      "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -11182,6 +11192,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.6.tgz",
       "integrity": "sha512-Yzpno3enVzSrSCnnljmr4b/2KUQSMZaPuqmS26t9k4nW7uwJk6STWmH9heNjPuvqUTO3jOSPkHoKgO4+Dw7uIw=="
     },
+    "react-firebase-hooks": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-firebase-hooks/-/react-firebase-hooks-2.1.1.tgz",
+      "integrity": "sha512-6ZvAUa5q1JJrTQxCEKCXrP6S/en3B65RAYRYHbbjUh9f1BgKPsxkdaGGBPhGKuVSLUrVqTm8PtpZ/LCtAFogKA=="
+    },
     "react-is": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
@@ -11189,6 +11204,8 @@
     },
     "react-scripts": {
       "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.0.tgz",
+      "integrity": "sha512-pBqaAroFoHnFAkuX+uSK9Th1uEh2GYdGY2IG1I9/7HmuEf+ls3lLCk1p2GFYRSrLMz6ieQR/SyN6TLIGK3hKRg==",
       "requires": {
         "@babel/core": "7.8.4",
         "@svgr/webpack": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "firebase": "^7.9.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-firebase-hooks": "^2.1.1",
     "react-scripts": "3.4.0"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,39 +1,39 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import "./App.css";
+import { useObject } from "react-firebase-hooks/database";
 import { connection } from "./firebase-config";
 
 function App() {
-  const [count, setCount] = useState(null);
-  const isLoading = count === null;
+  const ref = connection.database().ref("counter");
+  const [value, loading, error] = useObject(ref);
 
-  const counter = connection.database().ref("counter");
-
-  useEffect(() => {
-    if (counter) {
-      counter.on("value", snapshot => {
-        const data = { value: snapshot.val(), id: snapshot.key };
-        setCount(data.value);
-      });
-    }
-  }, [counter]);
-
-  const setCounter = value => {
-    connection
-      .database()
-      .ref("counter")
-      .set(value);
+  const setCounter = newValue => {
+    ref.set(newValue);
   };
+
+  if (error) {
+    return (
+      <>
+        <h1>¯\_(ツ)_/¯</h1>
+        <h2>Something unexpected happened</h2>
+      </>
+    );
+  }
 
   return (
     <div className="App">
       <header className="App-header">
-        {isLoading ? (
+        {loading ? (
           <h1>Loading...</h1>
         ) : (
           <React.Fragment>
-            <h1>{count}</h1>
-            <button onClick={() => setCounter(count + 1)}>Increment</button>
-            <button onClick={() => setCounter(count - 1)}>Decrement</button>
+            <h1>{value.val()}</h1>
+            <button onClick={() => setCounter(value.val() + 1)}>
+              Increment
+            </button>
+            <button onClick={() => setCounter(value.val() - 1)}>
+              Decrement
+            </button>
           </React.Fragment>
         )}
       </header>

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,9 @@
 import React from "react";
 import "./App.css";
-import { useObject } from "react-firebase-hooks/database";
-import { connection } from "./firebase-config";
+import { useFirebaseDatabase } from "./hooks/firebase-hooks";
 
 function App() {
-  const ref = connection.database().ref("counter");
-  const [value, loading, error] = useObject(ref);
-
-  const setCounter = newValue => {
-    ref.set(newValue);
-  };
+  const { value, setValue, loading, error } = useFirebaseDatabase("counter");
 
   if (error) {
     return (
@@ -28,12 +22,8 @@ function App() {
         ) : (
           <React.Fragment>
             <h1>{value.val()}</h1>
-            <button onClick={() => setCounter(value.val() + 1)}>
-              Increment
-            </button>
-            <button onClick={() => setCounter(value.val() - 1)}>
-              Decrement
-            </button>
+            <button onClick={() => setValue(value.val() + 1)}>Increment</button>
+            <button onClick={() => setValue(value.val() - 1)}>Decrement</button>
           </React.Fragment>
         )}
       </header>

--- a/src/hooks/firebase-hooks.js
+++ b/src/hooks/firebase-hooks.js
@@ -1,0 +1,12 @@
+import { useObject } from "react-firebase-hooks/database";
+import { connection } from "../firebase-config";
+
+const useFirebaseDatabase = refName => {
+  const ref = connection.database().ref("counter");
+  const [value, loading, error] = useObject(ref);
+  const setValue = newValue => ref.set(newValue);
+
+  return { value, setValue, loading, error };
+};
+
+export { useFirebaseDatabase };


### PR DESCRIPTION
This PR  adds hooks to the repo.

The hooks are provided by [react-firebase-hooks](https://github.com/CSFrequency/react-firebase-hooks) and wrapped to also add a hook for setting the value of the ref (also exports the methods from the hook as an object instead of an array. This way, the order of destructuring is irrelevant).